### PR TITLE
Fix initializer deprecation

### DIFF
--- a/addon/initializers/csv.js
+++ b/addon/initializers/csv.js
@@ -1,4 +1,5 @@
-export function initialize(container, application) {
+export function initialize() {
+  var application = arguments[1] || arguments[0];
   application.inject('route', 'csv', 'service:csv');
   application.inject('component', 'csv', 'service:csv');
   application.inject('controller', 'csv', 'service:csv');

--- a/addon/initializers/excel.js
+++ b/addon/initializers/excel.js
@@ -1,4 +1,5 @@
-export function initialize(container, application) {
+export function initialize() {
+  var application = arguments[1] || arguments[0];
   application.inject('route', 'excel', 'service:excel');
   application.inject('component', 'excel', 'service:excel');
   application.inject('controller', 'excel', 'service:excel');


### PR DESCRIPTION
Per http://emberjs.com/deprecations/v2.x/#toc_initializer-arity initializers now have one argument.  The fix implemented works for both older versions with two arguments and newer versions with one.