### PR TITLE
ember-cli-htmlbars back in the latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   ],
   "dependencies": {
     "ember-select-list": "^0.9.5",
+    "ember-cli-htmlbars": "1.1.0",
     "xlsx": "^0.8.0"
   },
   "ember-addon": {


### PR DESCRIPTION
Because of deprecation errors the dependency ember-cli-htmlbars was completely removed. Now addon templates were detected, but there are no template compilers registered for `ember-cli-data-export`. Please make sure your template precompiler (commonly `ember-cli-htmlbars`) is listed in `dependencies` (NOT `devDependencies`) in `ember-cli-data-export`'s `package.json`.

Could you please bump the minor version of ember-cli-data-export and update the npm-package? Thanks in advance.
