### PR TITLE
Upgrade addon to ember-cli 2.11

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,17 +1,7 @@
 {
   "name": "ember-cli-data-export",
   "dependencies": {
-    "ember": "1.13.7",
-    "ember-cli-shims": "ember-cli/ember-cli-shims#0.0.3",
-    "ember-cli-test-loader": "ember-cli-test-loader#0.1.3",
-    "ember-data": "1.13.8",
-    "ember-load-initializers": "ember-cli/ember-load-initializers#0.1.5",
-    "ember-qunit": "0.4.9",
-    "ember-qunit-notifications": "0.0.7",
-    "ember-resolver": "~0.1.18",
     "jquery": "^1.11.3",
-    "loader.js": "ember-cli/loader.js#3.2.1",
-    "qunit": "~1.18.0",
     "file-saver": "*",
     "js-xlsx": "~0.8.0"
   },

--- a/package.json
+++ b/package.json
@@ -10,15 +10,38 @@
   "scripts": {
     "build": "ember build",
     "start": "ember server",
-    "test": "ember try:testall"
+    "test": "ember try:each"
   },
   "repository": "https://github.com/roofstock/ember-cli-data-export",
   "engines": {
-    "node": ">= 0.10.0"
+    "node": ">= 0.12.0"
   },
   "author": "Matt Armstrong",
   "license": "MIT",
-  "devDependencies": {},
+  "devDependencies": {
+    "broccoli-asset-rev": "^2.4.5",
+    "ember-ajax": "^2.4.1",
+    "ember-cli": "2.11.1",
+    "ember-cli-app-version": "^2.0.0",
+    "ember-cli-dependency-checker": "^1.3.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-htmlbars-inline-precompile": "^0.3.6",
+    "ember-cli-inject-live-reload": "^1.4.1",
+    "ember-cli-jshint": "^2.0.1",
+    "ember-cli-qunit": "^3.0.1",
+    "ember-cli-release": "^0.2.9",
+    "ember-cli-shims": "^1.0.2",
+    "ember-cli-sri": "^2.1.0",
+    "ember-cli-test-loader": "^1.1.0",
+    "ember-cli-uglify": "^1.2.0",
+    "ember-data": "^2.11.0",
+    "ember-disable-prototype-extensions": "^1.1.0",
+    "ember-export-application-global": "^1.0.5",
+    "ember-load-initializers": "^0.6.0",
+    "ember-resolver": "^2.0.3",
+    "ember-source": "~2.11.0",
+    "loader.js": "^4.0.10"
+  },
   "keywords": [
     "ember-addon",
     "ember-cli",
@@ -27,7 +50,8 @@
     "csv"
   ],
   "dependencies": {
-    "ember-cli-htmlbars": "1.1.0",
+    "ember-cli-htmlbars": "^1.1.1",
+    "ember-cli-babel": "^5.1.7",
     "ember-select-list": "^0.9.5",
     "xlsx": "^0.8.0"
   },


### PR DESCRIPTION
ember-cli-data-export failed to build in ember-cli 2.11 -- this should take care of it.